### PR TITLE
Fix typos in portfolio page

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
 							<div><strong style="font-size: 1.5rem;">Machine Learning & Data</strong></div>
 						</div>
 						<ul class="body-text">
-							<li><strong style="color: white;">ML framwork</strong>: Scikit-learn, PyTorch</li><br>
+                                                        <li><strong style="color: white;">ML framework</strong>: Scikit-learn, PyTorch</li><br>
 							<li><strong style="color: white;">Data Analysis</strong>: NumPy, Pandas, Matplotlib</li>
 						</ul>
 					</div>
@@ -453,7 +453,7 @@
 							Achieved over <strong class="brighter">4.5/5</strong> mean rating score from students, with top ratings in
 							technical ability & clarity on TA course evaluation
 						</li>
-						<li>Led weekly recitation. Hold Office Hour twice a week answering students' concerns. Graded
+                                                <li>Led weekly recitation and held office hours twice a week answering students' concerns. Graded
 							over <strong class="brighter">200</strong> quizzes and over <strong class="brighter">400</strong>
 							programming assignments</li>
 					</ul>
@@ -462,8 +462,8 @@
 							<img src="./images/tool-box.png">
 						</div>
 						<div class="skillset">
-							Technology used:&nbsp;Python, Pytest, Replit (Online IDE), Goodle Word Doc (task recording & grading
-							guildline), Excel (grades tracking)
+                                                        Technology used:&nbsp;Python, Pytest, Replit (Online IDE), Google Docs (task recording & grading
+                                                        guideline), Excel (grades tracking)
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- fix typo in ML framework section
- correct wording in teaching assistant description
- correct 'Google Docs' typo and 'guideline' spelling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685928b6d0588324a875c4b5ba9b45b4